### PR TITLE
Update manage_audit_paras reference UI

### DIFF
--- a/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
+++ b/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
@@ -52,6 +52,10 @@
 
         loadReferenceTypes();
 
+        $('#updateReferenceButton').on('click', function () {
+            $('#circularModal').modal('show');
+        });
+
         $('#referenceTypeSelect').on('change', function () {
             if ($(this).val() === "3") {
                 $('#circularModal').modal('show');
@@ -221,14 +225,28 @@
         $('#auditPara_Gist').val(v.obS_GIST);
         $('#paraTextViewer').val(v.parA_TEXT).trigger('change');
         $('#auditPara_AmountInv').val(v.amounT_INV);
-        $('#auditPara_InstNO').val(v.nO_INSTANCES);        
-        $('#referenceTypeSelect').val(v.referencE_TYPE || v.REFERENCE_TYPE);            
+        $('#auditPara_InstNO').val(v.nO_INSTANCES);
+        $('#referenceTypeSelect').val(v.referencE_TYPE || v.REFERENCE_TYPE);
         $('#divisionSelect').val(v.division || v.DIVISION);
         $('#instructionsTitle').val(v.instructionS_TITLE || v.INSTRUCTIONS_TITLE);
         $('#instructionsDetails').val(v.instructionsDetails || v.INSTRUCTIONS_DETAILS);
         $('#instructionsDate').val(v.instructionS_DATE || v.INSTRUCTIONS_DATE);
-               
-            
+
+        var instTitle = v.instructionS_TITLE || v.INSTRUCTIONS_TITLE;
+        if (instTitle) {
+            $('#referenceEdit').hide();
+            $('#referenceDisplay').show();
+            $('#display_referenceType').val(v.referencE_TYPE || v.REFERENCE_TYPE);
+            $('#display_division').val(v.division || v.DIVISION);
+            $('#display_instructionsTitle').val(instTitle);
+            $('#display_instructionsDate').val(v.instructionS_DATE || v.INSTRUCTIONS_DATE);
+            $('#display_instructionsDetails').val(v.instructionsDetails || v.INSTRUCTIONS_DETAILS);
+        } else {
+            $('#referenceDisplay').hide();
+            $('#referenceEdit').show();
+        }
+
+
         });
         ObservationResponsibles(index);
     }
@@ -250,11 +268,22 @@
             return;
         }
         g_selectedCircular = selected;
+        g_annexureRefId = g_selectedCircular.id || g_selectedCircular.ID || 0;
         $('#circularModal').modal('hide');
-            $('#divisionSelect').val(g_selectedCircular.entId).prop('readonly', true);
+        $('#divisionSelect').val(g_selectedCircular.entId).prop('disabled', true);
+        if ($('#instructionsTitle').is('select')) {
+            var ref = g_selectedCircular.referenceNo;
+            if ($('#instructionsTitle option[value="' + ref + '"]').length === 0) {
+                $('#instructionsTitle').append($('<option>', { value: ref, text: ref }));
+            }
             $('#instructionsTitle').val(ref).prop('disabled', true);
-             $('#instructionsTitle').val(g_selectedCircular.referenceNo).prop('readonly', true);
-              $('#instructionsDate').val(g_selectedCircular.issueDate ? g_selectedCircular.issueDate.split('T')[0] : '').prop('readonly', true);
+        } else {
+            $('#instructionsTitle').val(g_selectedCircular.referenceNo).prop('readonly', true);
+        }
+        $('#instructionsDate').val(g_selectedCircular.issueDate ? g_selectedCircular.issueDate.split('T')[0] : '').prop('readonly', true);
+        $('#display_division').val(g_selectedCircular.division || g_selectedCircular.Division || g_selectedCircular.DIVISION || '');
+        $('#display_instructionsTitle').val(g_selectedCircular.referenceNo);
+        $('#display_instructionsDate').val(g_selectedCircular.issueDate ? g_selectedCircular.issueDate.split('T')[0] : '');
                
     });
 
@@ -677,40 +706,69 @@ function updateObservationStatus() {
                         <label for="viewMemo_risk_display">Risk will be assigned on the basis of Selected Annexure</label>
                         <input id="viewMemo_risk_display" class="form-control" readonly />
                     </div>
-                    <!-- Reference Type and Instructions -->
-                    <div class="form-group mt-3">
-                        <label>Reference Type</label>
-                        <div class="row">
-                            <div class="col-md-6">
-                                <select id="referenceTypeSelect" class="form-select form-control">
-                                    <option value="0">--Select Reference Type--</option>
-                                </select>
+                    <div id="referenceEdit">
+                        <!-- Reference Type and Instructions -->
+                        <div class="form-group mt-3">
+                            <label>Reference Type</label>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <select id="referenceTypeSelect" class="form-select form-control">
+                                        <option value="0">--Select Reference Type--</option>
+                                    </select>
+                                </div>
+                                <div class="col-md-6">
+                                    <select id="divisionSelect" class="form-select form-control" style="display:none;" disabled>
+                                        <option value="0">--Select Division--</option>
+                                    </select>
+                                </div>
                             </div>
-                            <div class="col-md-6">
-                                <select id="divisionSelect" class="form-select form-control" style="display:none;" disabled>
-                                    <option value="0">--Select Division--</option>
-                                </select>
+                        </div>
+                        <div id="instructionFields" class="form-group mt-3" style="display:none;">
+                            <div class="row">
+                                <div class="col-md-4 mt-2">
+                                    <label for="instructionsTitle">Title/Chapter</label>
+                                    <select id="instructionsTitle" class="form-control" disabled>
+                                        <option value="">--Select or Add Title/Chapter--</option>
+                                    </select>
+                                    <input type="text" id="newInstructionsTitle" class="form-control mt-2" placeholder="Enter new title" style="display:none;" />
+                                    <div id="instructionCount" class="text-info mt-1"></div>
+                                </div>
+                                <div class="col-md-4 mt-2">
+                                    <label>Instructions Date</label>
+                                    <input id="instructionsDate" type="date" class="form-control" readonly />
+                                </div>
+                                <div class="col-md-4 mt-2">
+                                    <label>Instructions Details</label>
+                                    <textarea id="instructionsDetails" class="form-control"></textarea>
+                                </div>
                             </div>
                         </div>
                     </div>
-                    <div id="instructionFields" class="form-group mt-3" style="display:none;">
-                        <div class="row">
-                            <div class="col-md-4 mt-2">
-                                <label for="instructionsTitle">Title/Chapter</label>
-                                <select id="instructionsTitle" class="form-control" disabled>
-                                    <option value="">--Select or Add Title/Chapter--</option>
-                                </select>
-                                <input type="text" id="newInstructionsTitle" class="form-control mt-2" placeholder="Enter new title" style="display:none;" />
-                                <div id="instructionCount" class="text-info mt-1"></div>
-                            </div>
-                            <div class="col-md-4 mt-2">
-                                <label>Instructions Date</label>
-                                <input id="instructionsDate" type="date" class="form-control" readonly />
-                            </div>
-                            <div class="col-md-4 mt-2">
-                                <label>Instructions Details</label>
-                                <textarea id="instructionsDetails" class="form-control"></textarea>
-                            </div>
+
+                    <div id="referenceDisplay" class="mt-3" style="display:none;">
+                        <div class="form-group">
+                            <label class="font-weight-bold">Reference Type</label>
+                            <input id="display_referenceType" class="form-control" type="text" readonly />
+                        </div>
+                        <div class="form-group mt-2">
+                            <label class="font-weight-bold">Division</label>
+                            <input id="display_division" class="form-control" type="text" readonly />
+                        </div>
+                        <div class="form-group mt-2">
+                            <label class="font-weight-bold">Title/Chapter</label>
+                            <input id="display_instructionsTitle" class="form-control" type="text" readonly />
+                        </div>
+                        <div class="form-group mt-2">
+                            <label class="font-weight-bold">Instructions Date</label>
+                            <input id="display_instructionsDate" class="form-control" type="text" readonly />
+                        </div>
+                        <div class="form-group mt-2">
+                            <label class="font-weight-bold">Instructions Details</label>
+                            <textarea id="display_instructionsDetails" class="form-control" readonly></textarea>
+                        </div>
+                        <div class="form-group mt-2">
+                            <label class="form-label">Do you want to update the reference?</label>
+                            <button type="button" id="updateReferenceButton" class="btn btn-primary">Update</button>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- add read-only reference display with Update option
- open circular modal from Update button
- populate display fields when a circular is selected
- show reference details when existing observation has instructions

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ffb26210c832ea94b36f939a5dd2b